### PR TITLE
fix for bug: always dark theme if isDarkOS is true after page reload or navigation

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,7 +13,7 @@ function initializeThemeSwitcher() {
 
     const isDarkOS = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = localStorage.getItem("theme");
-    if (theme === "dark" || isDarkOS) {
+    if ((theme === "dark" || isDarkOS) && theme !== "light") {
         document.body.className = "dark-theme";
         themeSwitch.checked = true;
     }


### PR DESCRIPTION
If you have a dark theme enabled in the OS, you will always have a dark theme on your site when you reload the page or navigate to another. Even if you have a light theme in your localStorage. https://jumpshare.com/v/WxIcDO9rfdjIrtKillvt
I'm sorry if it looks like "душнить" :) 