### PR TITLE
Add CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+os: linux
+dist: bionic
+language: python
+python:
+  - "3.7"
+addons:
+  apt:
+    packages:
+      - "shellcheck"
+install:
+  - "pip install -r ./requirements-test.txt"
+script:
+  - "make test-ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ addons:
   apt:
     packages:
       - "shellcheck"
-install:
-  - "pip install -r ./requirements-test.txt"
 script:
   - "make test-ci"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.7-slim-buster
 
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install --no-install-recommends -yq \
+      make \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 ARG requirements=requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
 FROM python:3.7-slim-buster
 
+ARG requirements=requirements.txt
+
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install --no-install-recommends -yq \
+      gcc \
+      libc-dev \
+      libpq-dev \
       make \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-ARG requirements=requirements.txt
 
 ADD . /app
 
-RUN pip install --no-cache-dir -e .
-RUN pip install --no-cache-dir -r $requirements
+RUN pip install --no-cache-dir -e . \
+    && pip install --no-cache-dir -r $requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-slim-buster
 
 WORKDIR /app
 ARG requirements=requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ mypy:  ## Check types with mypy
 run:  ## Runs dev server
 	@python3 manage.py runserver
 
+test-ci: test-requirements lint mypy  ## Run tests (intended for CI usage)
+
+test-requirements:  ## Install requirements to run tests
+	@pip3 install -r ./requirements-test.txt"
+
+
 .PHONY: \
   dev-requirements \
   docker_run \

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,6 @@ test-requirements:  ## Install requirements to run tests
   lint \
   migrate \
   mypy \
-  run
+  run \
+  test-ci \
+  test-requirements

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ test-ci: test-requirements lint mypy  ## Run tests (intended for CI usage)
 test-requirements:  ## Install requirements to run tests
 	@pip3 install -r ./requirements-test.txt
 
-
 .PHONY: \
   dev-requirements \
   docker_run \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run:  ## Runs dev server
 test-ci: test-requirements lint mypy  ## Run tests (intended for CI usage)
 
 test-requirements:  ## Install requirements to run tests
-	@pip3 install -r ./requirements-test.txt"
+	@pip3 install -r ./requirements-test.txt
 
 
 .PHONY: \

--- a/README.md
+++ b/README.md
@@ -2,8 +2,20 @@
 
 Experimental project
 
+### Build and run
+
+```shell script
+docker-compose up --build
+```
+
 ### Run
 
+```shell script
+docker-compose up
 ```
-$ docker-compose up
+
+### Terminate
+
+```shell script
+docker-compose down --remove-orphans
 ```

--- a/infomate/settings.py
+++ b/infomate/settings.py
@@ -119,7 +119,10 @@ MEDIA_UPLOAD_CODE = None  # should be set in private_settings.py
 
 try:
     # poor mans' private settings
-    from infomate.private_settings import *
+    # As due to obvious reasons this file is missing in the repository, suppress the following 'pyflakes' error codes:
+    # - F401 'infomate.private_settings.*' imported but unused
+    # - F403 'from infomate.private_settings import *' used; unable to detect undefined names
+    from infomate.private_settings import *  # noqa: F401 F403
 except ImportError:
     pass
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+flake8
+mypy
+pylint
+requests
+yamllint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.8
-psycopg2==2.8.3
+psycopg2-binary==2.8.4
 click==7.0
 pillow==7.0
 awesome-slugify>=1.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.8
-psycopg2-binary==2.8.4
+psycopg2==2.8.4
 click==7.0
 pillow==7.0
 awesome-slugify>=1.6.5


### PR DESCRIPTION
As per https://github.com/vas3k/infomate.club/issues/6, this is first PR that adds Travis CI basic support.

Changes:
- Added Travis CI integration
- Switched to much smaller Docker image `3.7-buster-slim` (default is [`3.7-buster`](https://hub.docker.com/_/python) - see `Shared tags` section), add installing missing `make`, `gcc`, `libc` headers and `libpq-dev` (latter three are required for `psycopg2` build). This may look controversial, but as it results in much smaller final image size (`592MB`@`3.7-buster-slim` vs. `1.22GB`@`3.7`), so I would propose to accept this change.
- `psycopg2` version bumped to `2.8.4`. As a side note: Building this library on `macOS Catalina` was quite painful (required setting additional paths for `pg_config` and `libssl@1.1`). Shall we document this or let Catalina users to vanish in pain every time? :)
- Suppress `pyflakes` errors on missing secrets file
- Extended `docker-compose usage`

I've setup Travis CI for the fork to build branches and so far it [passed the test](https://travis-ci.org/vovinacci/infomate.club/branches).

Tested `docker-compose up` and `docker_run` make target - `OK`