### PR TITLE
Fix visual bug related to macOS color theme

### DIFF
--- a/infomate/settings.py
+++ b/infomate/settings.py
@@ -10,7 +10,7 @@ DEBUG = os.getenv("DEBUG", True)
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = "wow so secret"
-ALLOWED_HOSTS = ["127.0.0.1", "vas3k.ru", "infomate.club"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "vas3k.ru", "infomate.club"]
 
 INSTALLED_APPS = [
     "django.contrib.staticfiles",

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,11 +6,40 @@ function initializeThemeSwitcher() {
         if (e.target.checked) {
             theme = 'dark';
         }
-
-        document.documentElement.setAttribute('theme', theme);
-        localStorage.setItem('theme', theme);
+        switchTheme(theme);
     }, false);
 
+    checkMacTheme();
+    synctTheThemeSwitcher();
+}
+
+function checkMacTheme() {
+    if (window.matchMedia) {
+        const darkThemeMatch = window.matchMedia('(prefers-color-scheme: dark)');
+        let theme = 'light';
+        if (darkThemeMatch.matches) {
+            theme = 'dark';
+        }
+        switchTheme(theme)
+        darkThemeMatch.addListener((e) => {
+            if (e.matches) {
+                theme = 'dark';
+            } else {
+                theme = 'light';
+            }
+            switchTheme(theme);
+            synctTheThemeSwitcher();
+        })
+    }
+}
+
+function switchTheme(theme) {
+    document.documentElement.setAttribute('theme', theme);
+    localStorage.setItem('theme', theme);
+}
+
+function synctTheThemeSwitcher() {
+    const themeSwitch = document.querySelector('.theme-switcher input[type="checkbox"]');
     const theme = localStorage.getItem('theme');
     if (theme !== null) {
         themeSwitch.checked = (theme === 'dark');


### PR DESCRIPTION
Closing the #9  issue by:

- Adding the logic for checking current macOS color theme and setting switcher's state by it
- Creating a listener for macOS color theme state to be able to switch color and switcher state reactively