### PR TITLE
Disable native tooltip in Safari on macOS for article titles

### DIFF
--- a/templates/board.html
+++ b/templates/board.html
@@ -68,7 +68,7 @@
                                 <div class="articles feed-articles">
                                     {% for article in articles %}
                                         <div class="article {% if article.is_fresh %}is-article-fresh{% endif %}">
-                                            <div class="article-title">{{ article.icon|safe }}<a href="{{ article.url }}" target="_blank">{{ article.title|striptags }}</a></div>
+                                            <div class="article-title">{{ article.icon|safe }}<a href="{{ article.url }}" target="_blank"><div/>{{ article.title|striptags }}</a></div>
                                             <a href="{{ article.url }}" class="article-tooltip" target="_blank">
                                                 {% if article.image %}
                                                     <img src="{{ article.image }}" alt="{{ article.title|striptags }}" class="article-tooltip-image">

--- a/templates/board.html
+++ b/templates/board.html
@@ -68,7 +68,7 @@
                                 <div class="articles feed-articles">
                                     {% for article in articles %}
                                         <div class="article {% if article.is_fresh %}is-article-fresh{% endif %}">
-                                            <div class="article-title">{{ article.icon|safe }}<a href="{{ article.url }}" target="_blank"><div/>{{ article.title|striptags }}</a></div>
+                                            <div class="article-title">{{ article.icon|safe }}<a href="{{ article.url }}" target="_blank"><div></div>{{ article.title|striptags }}</a></div>
                                             <a href="{{ article.url }}" class="article-tooltip" target="_blank">
                                                 {% if article.image %}
                                                     <img src="{{ article.image }}" alt="{{ article.title|striptags }}" class="article-tooltip-image">


### PR DESCRIPTION
Всплывашка уже классная, а Сафари подсовывает ещё одну.
Другие браузеры так не делают.

Этот новый `<div/>` блокирует нативную подсказку в заголовках статей, ничего не меняя визуально.

Неплохо бы потестить в других браузерах.

<img width="433" alt="image" src="https://user-images.githubusercontent.com/2227358/73446801-84b2df00-436e-11ea-8094-3427159162ca.png">
