### PR TITLE
css fix: article tooltip visibility delay added

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -261,7 +261,7 @@
     }
 
     .article-tooltip {
-        display: none;
+        visibility: hidden;
         position: absolute;
         bottom: 25px;
         left: 0;
@@ -277,7 +277,8 @@
     }
 
         .article:hover > .article-tooltip {
-            display: block;
+            visibility: visible;
+            transition: visibility 0.1s;
         }
 
         .article-tooltip-image {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,8 +20,8 @@ function initializeThemeSwitcher() {
 function hideTooltip() {
     let visibleTooltips = document.querySelectorAll(".article-tooltip");
     for (let i = 0; i < visibleTooltips.length; i++) {
-        if (visibleTooltips[i].style.display !== "none") {
-            visibleTooltips[i].style.display = null;
+        if (visibleTooltips[i].style.visibility !== "hidden") {
+            visibleTooltips[i].style.visibility = 'hidden';
         }
     }
 }
@@ -38,10 +38,10 @@ function checkKeyPress(e) {
 
     if (e.keyCode == 81) {
         tooltip = document.activeElement.parentNode.parentNode.querySelector('.article-tooltip');
-        if (tooltip.style.display == "block") {
-            tooltip.style.display = null;
+        if (tooltip.style.visibility == "visible") {
+            tooltip.style.visibility = "hidden";
         } else {
-            tooltip.style.display = "block";
+            tooltip.style.visibility = "visible";
         }
     }
 


### PR DESCRIPTION
Article tooltip visibility delay :)
Because it's not always possible to translate pointer to it.


**Before:**
![before](https://user-images.githubusercontent.com/13254668/74840132-818c8c80-5337-11ea-9a4a-ade20829f5c9.gif)


**After:**
![after](https://user-images.githubusercontent.com/13254668/74840139-83565000-5337-11ea-8e3a-58ae94e93b49.gif)


