### PR TITLE
issue#20: update allowed hosts & fix export btn hover

### DIFF
--- a/infomate/settings.py
+++ b/infomate/settings.py
@@ -10,7 +10,7 @@ DEBUG = os.getenv("DEBUG", True)
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = "wow so secret"
-ALLOWED_HOSTS = ["127.0.0.1", "0.0.0.0", "vas3k.ru", "infomate.club"]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "vas3k.ru", "infomate.club"]
 
 INSTALLED_APPS = [
     "django.contrib.staticfiles",

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -342,7 +342,7 @@
 
     .export-button {
         display: inline-block;
-        color: var(--opposite-text-color);
+        color: var(--opposite-text-color) !important;
         font-size: 90%;
         padding: 10px 20px;
         margin-top: 40px;
@@ -391,17 +391,17 @@
     min-height: 400px;
 }
 
-.coming-soon {
-    display: block;
-    max-width: 500px;
-    margin: 0 auto;
-    padding: 100px 20px;
-}
+    .coming-soon {
+        display: block;
+        max-width: 500px;
+        margin: 0 auto;
+        padding: 100px 20px;
+    }
 
-.coming-soon h2 {
-    font-size: 200%;
-}
+        .coming-soon h2 {
+            font-size: 200%;
+        }
 
-.coming-soon p {
-    font-size: 120%;
-}
+        .coming-soon p {
+            font-size: 120%;
+        }

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -342,7 +342,7 @@
 
     .export-button {
         display: inline-block;
-        color: var(--opposite-text-color) !important;
+        color: var(--opposite-text-color);
         font-size: 90%;
         padding: 10px 20px;
         margin-top: 40px;
@@ -391,17 +391,17 @@
     min-height: 400px;
 }
 
-    .coming-soon {
-        display: block;
-        max-width: 500px;
-        margin: 0 auto;
-        padding: 100px 20px;
-    }
+.coming-soon {
+    display: block;
+    max-width: 500px;
+    margin: 0 auto;
+    padding: 100px 20px;
+}
 
-        .coming-soon h2 {
-            font-size: 200%;
-        }
+.coming-soon h2 {
+    font-size: 200%;
+}
 
-        .coming-soon p {
-            font-size: 120%;
-        }
+.coming-soon p {
+    font-size: 120%;
+}

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -342,7 +342,7 @@
 
     .export-button {
         display: inline-block;
-        color: var(--opposite-text-color) !important;
+        color: var(--opposite-text-color);
         font-size: 90%;
         padding: 10px 20px;
         margin-top: 40px;


### PR DESCRIPTION
Fixes https://github.com/vas3k/infomate.club/issues/20

I didn't get the point of forcing white colour for export button text, if there is any hidden meaning, I can revert the changes. Also edited `settings.py` to allow `localhost`. 

before:

![image](https://user-images.githubusercontent.com/14779553/75190351-6911dd00-5750-11ea-8f49-ab100fa8a4ce.png)

after: 

![image](https://user-images.githubusercontent.com/14779553/75190380-78912600-5750-11ea-9087-8272a06ab076.png)

GIF:

![ezgif-1-a1f28f379569](https://user-images.githubusercontent.com/14779553/75192046-c9eee480-5753-11ea-932e-b648540d9169.gif)