### PR TITLE
Fix font size for Cybersecurity card to match hover boundaries.

### DIFF
--- a/boards.yml
+++ b/boards.yml
@@ -1370,7 +1370,7 @@ boards:
     is_visible: true
     is_private: false
     curator:
-      name: Кибербезопасность
+      name: Кибер-безопасность
       url: от %username%
       avatar: https://i.vas3k.ru/j62.jpg
       bio: Подборка ресурсов по кибербезопасности

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -77,7 +77,7 @@
 
         .landing-board-name {
             display: block;
-            font-size: 160%;
+            font-size: 140%;
             line-height: 115%;
             margin: 10px 0 5px;
             font-weight: bold;

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -77,10 +77,12 @@
 
         .landing-board-name {
             display: block;
-            font-size: 140%;
+            font-size: 160%;
             line-height: 115%;
             margin: 10px 0 5px;
             font-weight: bold;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .landing-board-title {


### PR DESCRIPTION
Fix font size for Cybersecurity card to match hover boundaries, screenshot of suggested font size:
<img width="168" alt="image" src="https://github.com/vas3k/infomate.club/assets/10785563/9e991bf2-f140-42c6-bf69-937d0d60ba9b">
Fixes issue #64 
